### PR TITLE
[frontend] Some minor improvements

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5392,7 +5392,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5410,11 +5411,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5427,15 +5430,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5538,7 +5544,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5548,6 +5555,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5560,17 +5568,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5587,6 +5598,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5659,7 +5671,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5669,6 +5682,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5744,7 +5758,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5774,6 +5789,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5791,6 +5807,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5829,11 +5846,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/frontend/src/api/msaApi.js
+++ b/frontend/src/api/msaApi.js
@@ -17,4 +17,4 @@ class MsaApi {
             })
     }
 }
-export default MsaApi; 
+export default MsaApi;

--- a/frontend/src/representation/AttackListItem.js
+++ b/frontend/src/representation/AttackListItem.js
@@ -24,6 +24,7 @@ class AttackListItem extends Component {
             <li id={id} className={classes} draggable={true} onDragStart={this.drag}>
                 <span>{name}</span>
                 <span>[{attackers}]&nbsp;&nbsp;&nbsp;{'→'}&nbsp;&nbsp;&nbsp;[{victims}]</span>
+                <br/>
                 <span>{moment(start).format(constants.TIME_FORMAT)}&nbsp;&nbsp;&nbsp;{'→'}&nbsp;&nbsp;&nbsp;{moment(end).format(constants.TIME_FORMAT)}</span>
             </li>
         );

--- a/frontend/src/representation/AttackListItem.js
+++ b/frontend/src/representation/AttackListItem.js
@@ -23,7 +23,7 @@ class AttackListItem extends Component {
         return (
             <li id={id} className={classes} draggable={true} onDragStart={this.drag}>
                 <span>{name}</span>
-                <span>[{attackers}]&nbsp;&nbsp;&nbsp;{'→'}&nbsp;&nbsp;&nbsp;[{victims}]</span>
+                <span>[{attackers.join(', ')}]&nbsp;&nbsp;&nbsp;{'→'}&nbsp;&nbsp;&nbsp;[{victims.join(', ')}]</span>
                 <br/>
                 <span>{moment(start).format(constants.TIME_FORMAT)}&nbsp;&nbsp;&nbsp;{'→'}&nbsp;&nbsp;&nbsp;{moment(end).format(constants.TIME_FORMAT)}</span>
             </li>

--- a/frontend/src/representation/TraceFileList.js
+++ b/frontend/src/representation/TraceFileList.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types'
+import moment from 'moment';
 import TraceFileListItem from './TraceFileListItem'
 import './List.css'
 
@@ -14,6 +15,31 @@ class TraceFileList extends Component {
         });
         return traceFiles;
     }
+    compareEntries(entry_a, entry_b) {
+        var a = entry_a[1]
+        var b = entry_b[1]
+
+        var ts_a = moment(a.firstPacket).format('YYYY-MM-DD')
+        var ts_b = moment(b.firstPacket).format('YYYY-MM-DD')
+        var ip_a = a.mostFrequentIp
+        var ip_b = b.mostFrequentIp
+
+        if (ts_a < ts_b) {
+            return -1;
+        }
+        if (ts_a > ts_b) {
+            return 1;
+        }
+
+        // dates are equal, compare ip second
+        if (ip_a < ip_b) {
+            return -1;
+        }
+        if (ip_a > ip_b) {
+            return 1;
+        }
+        return 0;
+    }
     render() {
 
         return (
@@ -21,8 +47,10 @@ class TraceFileList extends Component {
                 <h3>Trace Files (Noise)</h3>
                 <p>Drag and drop trace files into days of the timeline.</p>
                 <ul>
-                {Object.entries(this.getVisibleTracefiles()).map(entry => (
-                    <TraceFileListItem key={entry[0]} {...entry[1]} />
+                {Object.entries(this.getVisibleTracefiles())
+                    .sort(this.compareEntries)
+                    .map(entry => (
+                        <TraceFileListItem key={entry[0]} {...entry[1]} />
                 ))}
                 </ul>
             </div>

--- a/frontend/src/representation/TraceFileListItem.js
+++ b/frontend/src/representation/TraceFileListItem.js
@@ -24,7 +24,8 @@ class TraceFileListItem extends Component {
             <li className={classes} id={id} draggable={true} onDragStart={this.drag}>
                 <span>{mostFrequentIp}</span>
                 <span>{moment(firstPacket).format(constants.TIME_FORMAT)}&nbsp;&nbsp;&nbsp;{'→'}&nbsp;&nbsp;&nbsp;{moment(lastPacket).format(constants.TIME_FORMAT)}</span>
-                <span>{packets}&nbsp;pkt</span>
+                <br/>
+                <span>Total {packets}&nbsp;pkt</span>
                 <span>{packetsPerSecond}&nbsp;pkt/s</span>
             </li>
         );


### PR DESCRIPTION
1. Sort trace files by day (of the first packet) and for same days by most frequent IP. Startup takes slightly longer but as trace files are only fetched once, this is negligible. Also slightly improve layout by adding line breaks for the two list items.
2. Separate multiple IP addresses by comma for better visual grepping