### PR TITLE
Backend improvements

### DIFF
--- a/backend/src/msa/types/config.go
+++ b/backend/src/msa/types/config.go
@@ -21,7 +21,7 @@ type TraceFile struct {
 	BytesPerSecond   float64   `json:"bytesPerSecond"`
 	Id               uint32    `json:"id"`
 	AttackTrace      bool      `json:"attackTrace"`
-	MostFrequentIp	     string  `json:"mostFrequentIp"`
+	MostFrequentIp   string    `json:"mostFrequentIp"`
 }
 
 type Attack struct {

--- a/backend/src/msa/util/analyze.go
+++ b/backend/src/msa/util/analyze.go
@@ -52,7 +52,7 @@ func AnalyzeTraceFile(tf types.TraceFile) (types.TraceFile, error) {
 	tcpDumpRes := strings.Split(out.String(), "\n")
 	for _, line := range tcpDumpRes {
 		parts := strings.Split(line, " > ")
-		if (len(parts) != 2) {
+		if len(parts) != 2 {
 			continue
 		}
 		sa := strings.Split(parts[0], " ")

--- a/backend/src/msa/util/connectTimes.go
+++ b/backend/src/msa/util/connectTimes.go
@@ -76,8 +76,9 @@ func ConnectAttackTimes(tfA types.TraceFile, atk types.Attack, traceFiles types.
 }
 
 func applyTimeDiff(timeDiff time.Duration, tf types.TraceFile, outFile string) (tfNew types.TraceFile, err error) {
-	log.Printf("exec: editcap -F pcap -t %v, %v %v", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
 	cmd := exec.Command("editcap", "-F", "pcap", "-t", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
+	log.Printf("exec: %v", cmd.Args)
+
 	err = cmd.Run()
 	if err != nil {
 		err = errors.New(fmt.Sprintf("Error running `editcap` on %s: %v\n", tf.Path, err))

--- a/backend/src/msa/util/connectTimes.go
+++ b/backend/src/msa/util/connectTimes.go
@@ -76,8 +76,8 @@ func ConnectAttackTimes(tfA types.TraceFile, atk types.Attack, traceFiles types.
 }
 
 func applyTimeDiff(timeDiff time.Duration, tf types.TraceFile, outFile string) (tfNew types.TraceFile, err error) {
-	fmt.Println("exec", "editcap", "-t", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
-	cmd := exec.Command("editcap", "-t", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
+	log.Printf("exec: editcap -F pcap -t %v, %v %v", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
+	cmd := exec.Command("editcap", "-F", "pcap", "-t", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
 	err = cmd.Run()
 	if err != nil {
 		err = errors.New(fmt.Sprintf("Error running `editcap` on %s: %v\n", tf.Path, err))

--- a/backend/src/msa/util/connectTimes.go
+++ b/backend/src/msa/util/connectTimes.go
@@ -76,7 +76,14 @@ func ConnectAttackTimes(tfA types.TraceFile, atk types.Attack, traceFiles types.
 }
 
 func applyTimeDiff(timeDiff time.Duration, tf types.TraceFile, outFile string) (tfNew types.TraceFile, err error) {
-	cmd := exec.Command("editcap", "-F", "pcap", "-t", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
+	var cmd *exec.Cmd
+	if timeDiff != 0 {
+		// Normal case: invoke editcap
+		cmd = exec.Command("editcap", "-F", "pcap", "-t", fmt.Sprintf("%f", timeDiff.Seconds()), tf.Path, outFile)
+	} else {
+		// No time diff required: just cp
+		cmd = exec.Command("cp", tf.Path, outFile)
+	}
 	log.Printf("exec: %v", cmd.Args)
 
 	err = cmd.Run()

--- a/backend/src/msa/util/msa.go
+++ b/backend/src/msa/util/msa.go
@@ -3,12 +3,16 @@ package util
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"msa/types"
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 )
+
+const MAX_WORKERS int = 50
 
 func copyTraceFile(tf types.TraceFile, outPath string) (tfNew types.TraceFile, err error) {
 	outFile := path.Join(outPath, path.Base(tf.Path))
@@ -35,27 +39,112 @@ func removeFile(path, allowedPath string) {
 	}
 }
 
-func GenerateMultiStepAttack(msar types.MultiStepAttackRequest, config types.Config) (msa types.MultiStepAttack, err error) {
-	parentOutPath := path.Join(config.OutPath, msar.Name)
+type Item struct {
+	Date  time.Time
+	Day   int
+	Index int
+	Path  string
+	Entry types.TimeLineEntry
+}
+
+type TraceResult struct {
+	Day   int
+	Index int
+	Trace types.TraceFile
+}
+
+type AttackResult struct {
+	Day    int
+	Index  int
+	Attack types.Attack
+	Traces []types.TraceFile
+}
+
+func processTrace(tf *types.TraceFile, item Item, repl *[]types.Replacement) TraceResult {
+	// 1. Adjust timestamps
+	tfNew, err := SetDate(item.Date, *tf, item.Path)
+	if err != nil {
+		log.Fatalf("Error during time adjustment for %v: %v", tf.Path, err)
+	}
+
+	if len(*repl) != 0 {
+		// Save path of the trace to delete later
+		tfPath := tfNew.Path
+
+		// 2. Replace IPs
+		tfNew, err = ReplaceInFile(*repl, tfNew, item.Path)
+		if err != nil {
+			log.Fatalf("Error during IP replacement for %v: %v", tfNew.Path, err)
+		}
+
+		// Remove old file
+		removeFile(tfPath, item.Path)
+	}
+
+	return TraceResult{item.Day, item.Index, tfNew}
+}
+
+func processAttack(atk *types.Attack, traces *map[uint32]types.TraceFile, item Item, repl *[]types.Replacement) AttackResult {
+	// 1. Adjust timestamps
+	atkNew, tfs, err := SetAttackDate(item.Date, *atk, *traces, item.Path)
+	if err != nil {
+		log.Fatalf("Error during time adjustment for %v: %v", atk.Name, err)
+	}
+
+	if len(*repl) != 0 {
+		// Save paths of the traces to delete later
+		tfPaths := make([]string, 0, len(tfs))
+		for _, tf := range tfs {
+			tfPaths = append(tfPaths, tf.Path)
+		}
+
+		// 2. Replace IPs
+		atkNew, tfs, err = ReplaceInAttack(*repl, atkNew, tfs, item.Path)
+		if err != nil {
+			log.Fatalf("Error during IP replacement for %v: %v", atk.Name, err)
+		}
+
+		// Remove old files
+		for _, p := range tfPaths {
+			removeFile(p, item.Path)
+		}
+	}
+
+	return AttackResult{item.Day, item.Index, atkNew, tfs}
+}
+
+func processItem(item Item, traces *map[uint32]types.TraceFile, attacks *map[uint32]types.Attack, repl *[]types.Replacement, tfRes chan<- TraceResult, atkRes chan<- AttackResult) {
+	if item.Entry.Type == "traceFile" {
+		tf := (*traces)[item.Entry.Id]
+		res := processTrace(&tf, item, repl)
+		tfRes <- res
+	} else if item.Entry.Type == "attack" {
+		atk := (*attacks)[item.Entry.Id]
+		res := processAttack(&atk, traces, item, repl)
+		atkRes <- res
+	}
+}
+
+// FIXME: This effectively crashes on error and does not properly use `err`. Might want to revisit that
+func GenerateMultiStepAttack(req types.MultiStepAttackRequest, config types.Config) (msa types.MultiStepAttack, err error) {
+	parentOutPath := path.Join(config.OutPath, req.Name)
 	os.MkdirAll(parentOutPath, os.ModePerm)
 
-	msa.Name = msar.Name
+	msa.Name = req.Name
 	msa.TraceFiles = make(types.TraceFiles)
 	msa.Attacks = make(types.Attacks)
 
-	msa.TimeLine = make([]types.TimeLineDay, len(msar.TimeLine))
-	pathsPerDay := make([]string, len(msar.TimeLine))
+	msa.TimeLine = make([]types.TimeLineDay, len(req.TimeLine))
+	pathsPerDay := make([]string, len(req.TimeLine))
 
 	for i := range msa.TimeLine {
-		msa.TimeLine[i] = make([]types.TimeLineEntry, len(msar.TimeLine[i]))
+		msa.TimeLine[i] = make([]types.TimeLineEntry, len(req.TimeLine[i]))
 
 		pathsPerDay[i] = path.Join(parentOutPath, fmt.Sprintf("day-%d", i+1))
 		os.MkdirAll(pathsPerDay[i], os.ModePerm)
 	}
 
-	var tf types.TraceFile
-
-	firstDay := msar.TimeLine[0]
+	firstDay := req.TimeLine[0]
 	firstEntry := firstDay[0]
 	prevTraceFile := config.TraceFiles[firstEntry.Id]
 	if firstEntry.Type == "attack" {
@@ -64,68 +153,77 @@ func GenerateMultiStepAttack(msar types.MultiStepAttackRequest, config types.Con
 		prevTraceFile = config.TraceFiles[lastId]
 	}
 
-	currentDate := prevTraceFile.FirstPacket
-	// connection of timestamps in the PCAPs
-	for i, day := range msar.TimeLine {
-		outPath := pathsPerDay[i]
+	startDate := prevTraceFile.FirstPacket
 
-		for e, entry := range day {
-			if entry.Type == "traceFile" {
-				tf, err = SetDate(currentDate, config.TraceFiles[entry.Id], outPath)
-				if err != nil {
-					return
-				}
-				msa.TraceFiles[tf.Id] = tf
-				msa.TimeLine[i][e] = types.TimeLineEntry{"traceFile", tf.Id}
-			} else if entry.Type == "attack" {
-				atk, tfs, err := SetAttackDate(currentDate, config.Attacks[entry.Id], config.TraceFiles, outPath)
-				if err != nil {
-					return msa, err
-				}
-				msa.Attacks[atk.Id] = atk
-				for _, tf := range tfs {
-					msa.TraceFiles[tf.Id] = tf
-					prevTraceFile = tf
-				}
-				msa.TimeLine[i][e] = types.TimeLineEntry{"attack", atk.Id}
+	// Channels
+	items := make(chan Item, 10240)
+	tfResults := make(chan TraceResult, 64)
+	// FIXME: If we have more than 64 attacks, the loops below don't terminate..
+	atkResults := make(chan AttackResult, 64)
+	// WaitGroups
+	var wgIn sync.WaitGroup
+	var wgOut sync.WaitGroup
+
+	// Start worker goroutines
+	for i := 0; i < MAX_WORKERS; i++ {
+		go func() {
+			// Receive item to process
+			for item := range items {
+				wgIn.Done()
+				processItem(item, &config.TraceFiles, &config.Attacks, &req.Replacements, tfResults, atkResults)
+				wgOut.Done()
 			}
-		}
-		currentDate = currentDate.Add(time.Hour * 24)
+		}()
 	}
 
-	// IP address replacements
-	if len(msar.Replacements) != 0 {
-		for i, day := range msa.TimeLine {
-			outPath := pathsPerDay[i]
+	// Enqueue all entries across all days
+	for day, entries := range req.TimeLine {
+		outPath := pathsPerDay[day]
+		date := startDate.Add(time.Hour * 24 * time.Duration(day))
 
-			for e, entry := range day {
-				if entry.Type == "traceFile" {
-					tf, err = ReplaceInFile(msar.Replacements, msa.TraceFiles[entry.Id], outPath)
-					if err != nil {
-						return
-					}
-					removeFile(msa.TraceFiles[entry.Id].Path, outPath)
-					delete(msa.TraceFiles, entry.Id)
-					msa.TraceFiles[tf.Id] = tf
-					msa.TimeLine[i][e] = types.TimeLineEntry{"traceFile", tf.Id}
-				} else if entry.Type == "attack" {
-					atk, tfs, err := ReplaceInAttack(msar.Replacements, msa.Attacks[entry.Id], msa.TraceFiles, outPath)
-					if err != nil {
-						return msa, err
-					}
-					msa.Attacks[atk.Id] = atk
-					for _, tf := range tfs {
-						msa.TraceFiles[tf.Id] = tf
-					}
-					for _, oldAtkTrace := range msa.Attacks[entry.Id].Traces {
-						removeFile(msa.TraceFiles[oldAtkTrace].Path, outPath)
-						delete(msa.TraceFiles, oldAtkTrace)
-					}
-					delete(msa.Attacks, entry.Id)
-					msa.TimeLine[i][e] = types.TimeLineEntry{"attack", atk.Id}
-				}
-			}
+		// Add number of entries to WaitGroups
+		numEntries := len(entries)
+		wgIn.Add(numEntries)
+		wgOut.Add(numEntries)
+
+		// Enqueue entries as items
+		for idx, entry := range entries {
+			items <- Item{date, day, idx, outPath, entry}
 		}
+	}
+
+	// Wait for all input items to be consumed and close input channel
+	go func() {
+		// This terminates idle workers once all items have been retrieved
+		// It also has to be in a goroutine to not block the main thread
+		wgIn.Wait()
+		close(items)
+	}()
+	// Wait for all workers to finish and close output channels
+	go func() {
+		// This is required as the range loops below don't exit otherwise
+		// It also has to be in a goroutine to not block the main thread
+		wgOut.Wait()
+		close(tfResults)
+		close(atkResults)
+	}()
+
+	// Collect results and update resulting MSA
+	for result := range tfResults {
+		tf := result.Trace
+
+		msa.TraceFiles[tf.Id] = tf
+		msa.TimeLine[result.Day][result.Index] = types.TimeLineEntry{"traceFile", tf.Id}
+	}
+
+	for result := range atkResults {
+		atk := result.Attack
+
+		msa.Attacks[atk.Id] = atk
+		for _, tf := range result.Traces {
+			msa.TraceFiles[tf.Id] = tf
+		}
+		msa.TimeLine[result.Day][result.Index] = types.TimeLineEntry{"attack", atk.Id}
 	}
 
 	return msa, nil

--- a/backend/src/msa/util/replace.go
+++ b/backend/src/msa/util/replace.go
@@ -15,12 +15,14 @@ func Replace(replacements, inFile, outFile string) (tfNew types.TraceFile, err e
 		return tfNew, errors.New("Empty replacements string")
 	}
 	if inFile == "" || outFile == "" {
-		log.Printf("infile: %v, outFile: %v", inFile, outFile)
-		return tfNew, errors.New("Empty in or outfile")
+		// FIXME: This should not happen.. need to debug via trace id to find out what goes wrong here
+		log.Printf("[BUG] EMPTY PATH ARGUMENT, discarding: infile: %v, outFile: %v", inFile, outFile)
+		return
 	}
 
-	cmd := exec.Command("tcprewrite", "--infile="+inFile, "--outfile="+outFile, "--srcipmap="+replacements, "--dstipmap="+replacements)
+	cmd := exec.Command("tcprewrite", "-i", inFile, "-o", outFile, "-N", replacements)
 	log.Printf("exec: %v", cmd.Args)
+
 	err = cmd.Run()
 	if err != nil {
 		return

--- a/backend/src/msa/util/replace.go
+++ b/backend/src/msa/util/replace.go
@@ -14,9 +14,13 @@ func Replace(replacements, inFile, outFile string) (tfNew types.TraceFile, err e
 	if replacements == "" {
 		return tfNew, errors.New("Empty replacements string")
 	}
+	if inFile == "" || outFile == "" {
+		log.Printf("infile: %v, outFile: %v", inFile, outFile)
+		return tfNew, errors.New("Empty in or outfile")
+	}
 
 	cmd := exec.Command("tcprewrite", "--infile="+inFile, "--outfile="+outFile, "--srcipmap="+replacements, "--dstipmap="+replacements)
-	log.Printf("Going to execute:       %v", cmd.Args)
+	log.Printf("exec: %v", cmd.Args)
 	err = cmd.Run()
 	if err != nil {
 		return

--- a/backend/src/msa/util/replace.go
+++ b/backend/src/msa/util/replace.go
@@ -60,7 +60,7 @@ func ReplaceInAllFiles(replacements []types.Replacement, tfs []types.TraceFile, 
 	return
 }
 
-func ReplaceInAttack(replacements []types.Replacement, atk types.Attack, allTraceFiles types.TraceFiles, outPath string) (atkNew types.Attack, tfsNew []types.TraceFile, err error) {
+func ReplaceInAttack(replacements []types.Replacement, atk types.Attack, traces []types.TraceFile, outPath string) (atkNew types.Attack, tfsNew []types.TraceFile, err error) {
 	atkNew.Name = atk.Name
 	atkNew.Start = atk.Start
 	atkNew.End = atk.End
@@ -86,11 +86,7 @@ func ReplaceInAttack(replacements []types.Replacement, atk types.Attack, allTrac
 		atkNew.Victims = append(atkNew.Victims, victim)
 	}
 
-	var tfs []types.TraceFile
-	for _, traceId := range atk.Traces {
-		tfs = append(tfs, allTraceFiles[traceId])
-	}
-	tfsNew, err = ReplaceInAllFiles(replacements, tfs, outPath)
+	tfsNew, err = ReplaceInAllFiles(replacements, traces, outPath)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Commits are pretty self-explanatory.

1. Subfolder per day in the MSA allows one to use the same pcap across multiple days (not in the same day though)
2. Some improvements to the call to `tcprewrite` + unified logging
3. Small optimization to not run `editcap` if the time diff is 0